### PR TITLE
Allow multiple instances of identical operators

### DIFF
--- a/proxalgs/core.py
+++ b/proxalgs/core.py
@@ -75,7 +75,9 @@ class Optimizer(object):
         # if proxfun is a string, grab the corresponding function from operators.py
         if isinstance(proxfun, str):
             try:
-                op = getattr(operators, proxfun)
+                proxfun_name = proxfun.split(None, 1)[0]
+                # Ignore everything after white space
+                op = getattr(operators, proxfun_name)
                 self.objectives.append(lambda theta, rho: op(theta.copy(), float(rho), **kwargs))
 
             except AttributeError as e:

--- a/proxalgs/core.py
+++ b/proxalgs/core.py
@@ -75,7 +75,8 @@ class Optimizer(object):
         # if proxfun is a string, grab the corresponding function from operators.py
         if isinstance(proxfun, str):
             try:
-                self.objectives.append(lambda theta, rho: getattr(operators, proxfun)(theta.copy(), float(rho), **kwargs))
+                op = getattr(operators, proxfun)
+                self.objectives.append(lambda theta, rho: op(theta.copy(), float(rho), **kwargs))
 
             except AttributeError as e:
                 print(str(e) + '\n' + 'Could not find the function ' + proxfun + ' in the operators module!')


### PR DESCRIPTION
The same operator may be required as regularizer multiple times with different sets of parameters, e.g. `operators.smooth` with different values of its parameter `axis`.

When using `Optimizer.set_regularizers` to add regularizers in form of a `dict`, this is not possible, because of the fact the keys of a `dict` have to be unique. The following example thus fails.

```python
>>> regularizers = {
...     'smooth': {'axis': 0, 'gamma': 0.3},
...     'smooth': {'axis': 1, 'gamma': 0.5},
... }
>>> opt.set_regularizers(regularizers)
>>> len(opt.objectives) - 1  # Number of regualarizers - objfun
1
```

The changes made here will permit this, by ignoring everything past a first whitespace character in the name of the function passed to `Optimizer.add_regularizer`, thus allowing to add multiple regularizers of identical operator.

```python
>>> regularizers = {
...     'smooth 0': {'axis': 0, 'gamma': 0.3},
...     'smooth 1': {'axis': 1, 'gamma': 0.5},
... }
>>> opt.set_regularizers(regularizers)
>>> len(opt.objectives) - 1  # Number of regualarizers - objfun
2
```

Side note: The changes also fix an issue with error handling when fetching the name of an operator in `Optimizer.add_regularizer`, as described in bc88eab.