### PR TITLE
Improve linear approximation operator

### DIFF
--- a/proxalgs/operators.py
+++ b/proxalgs/operators.py
@@ -382,4 +382,4 @@ def linsys(x0, rho, P, q):
     theta : array_like
         The parameter vector found after running the proximal update step
     """
-    return np.linalg.solve(rho * np.eye(q.size) + P, rho * x0.copy() + q)
+    return np.linalg.solve(rho * np.eye(q.shape[0]) + P, rho * x0.copy() + q)


### PR DESCRIPTION
The proximal operator 'linsys' now correctly allows `b` to be a matrix (i.e. to have multiple columns). This turns solving `Ax = b` into `AX = B`.