### PR TITLE
Pass kwargs to external proximal operator functions

### DIFF
--- a/proxalgs/core.py
+++ b/proxalgs/core.py
@@ -85,7 +85,7 @@ class Optimizer(object):
 
         # if proxfun is a function, add it as its own proximal operator
         elif hasattr(proxfun, '__call__'):
-            self.objectives.append(lambda theta, rho: proxfun(theta.copy(), float(rho)))
+            self.objectives.append(lambda theta, rho: proxfun(theta.copy(), float(rho), **kwargs))
 
         # type of proxfun must be a string or a function
         else:


### PR DESCRIPTION
The additional parameters (`**kwargs`) are only passed to the proximal operator if it is provided as string:
https://github.com/ganguli-lab/proxalgs/blob/74f54467ad072d3229edea93fa84ddd98dd77c67/proxalgs/core.py#L81
If provided as a function, however, this is not the case:
https://github.com/ganguli-lab/proxalgs/blob/74f54467ad072d3229edea93fa84ddd98dd77c67/proxalgs/core.py#L88

These changes simply add the missing ``, **kwargs))`` to the end of that line.