### PR TITLE
Use input data types instead of defaulting to numpy.float64

### DIFF
--- a/proxalgs/core.py
+++ b/proxalgs/core.py
@@ -159,7 +159,8 @@ class Optimizer(object):
         # initialize lists of primal and dual variable copies, one for each objective
         orig_shape = theta_init.shape
         primals = [theta_init.flatten() for _ in range(num_obj)]
-        duals = [np.zeros(theta_init.size) for _ in range(num_obj)]
+        duals = [np.zeros(theta_init.size, dtype=theta_init.dtype)
+                 for _ in range(num_obj)]
         theta_avg = np.mean(primals, axis=0).ravel()
 
         # initialize penalty parameter

--- a/proxalgs/operators.py
+++ b/proxalgs/operators.py
@@ -382,4 +382,5 @@ def linsys(x0, rho, P, q):
     theta : array_like
         The parameter vector found after running the proximal update step
     """
-    return np.linalg.solve(rho * np.eye(q.shape[0]) + P, rho * x0.copy() + q)
+    return np.linalg.solve(rho * np.eye(q.shape[0], dtype=P.dtype) + P,
+                           rho * x0.copy() + q)


### PR DESCRIPTION
With these changes, the array `duals` is created with the data type of `theta_init` passed by the user. This way the return value of `Optimizer.minimize` matches the data type of the input. This allows - for example - to use 32 bit floats for the computation instead of the default 64 bit floats.